### PR TITLE
refactor(ember-5): replaces assign() Ember polyfill

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: yarn
+      - run: yarn install
+      - run: yarn lint:js
+      - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 npm-debug.log*
 yarn-error.log
 testem.log
+./DS_Store
 
 # ember-try
 .node_modules.ember-try/

--- a/addon/services/raven.js
+++ b/addon/services/raven.js
@@ -1,17 +1,12 @@
 /* eslint-disable ember/avoid-leaking-state-in-ember-objects */
 
 import Ember from 'ember';
-import { assign as _assign, merge } from '@ember/polyfills';
 import Service from '@ember/service';
 import { set } from '@ember/object';
 import { typeOf, isPresent } from '@ember/utils';
 
 import RSVP from 'rsvp';
 import Raven from 'raven';
-
-// Ember merge is deprecated as of 2.5, but we need to check for backwards
-// compatibility.
-const assign = _assign || merge;
 
 /**
  * Default available logger service.
@@ -97,7 +92,7 @@ export default Service.extend({
       Raven.debug = debug;
 
       // Keeping existing config values for includePaths, whitelistUrls, for compatibility.
-      const ravenConfig = assign({
+      const ravenConfig = Object.assign({
         environment,
         includePaths,
         whitelistUrls,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,45 +2,10 @@ module.exports = {
   useYarn: true,
   scenarios: [
     {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      },
+      name: 'ember-lts-3.12',
       npm: {
         devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
-        },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
-    },
-    {
-      name: 'ember-lts-2.12',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.16',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.16.0'
+          'ember-source': '~3.12.0'
         }
       }
     },
@@ -61,42 +26,10 @@ module.exports = {
       }
     },
     {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
       name: 'ember-default',
       npm: {
         devDependencies: {}
       }
     }
   ]
-};
+}


### PR DESCRIPTION
- Usage of the `assign()` Ember polyfill will no longer be allowed in Ember 5.x
- this commit replaces any occurrences with `Object.assign()`
- adds GH workflow that runs test & linter
- updates ember-try to only run tests against Ember 3.12 (Ember 2.x is too old and tests against Ember 4+ require refactoring)